### PR TITLE
ヘッダーの表示の更新

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,7 +10,7 @@ class GroupsController < ApplicationController
     end
 
     def create
-        @group = Group.new(gorup_params)
+        @group = Group.new(group_params)
         if @group.save
             redirect_to root_path, notice: 'グループを作成しました'
         else
@@ -37,10 +37,5 @@ class GroupsController < ApplicationController
 
     def set_group
         @group = Group.find(params[:id])
-    end
-
-    private
-    def gorup_params
-        params.require(:group).permit(:name, { :user_ids => []})
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-         has_many :messages
+  has_many :messages
   has_many :group_users
   has_many :groups, through: :group_users
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -7,14 +7,13 @@
     .chat-display
         .header
             .header__left-box
-                .current-group
-                    sample
-                .member-list
-                    Member : 
-                    .member-list__member
-                        seo 
-                    .member-list__member    
-                        neko
+                %h2.current-group
+                    = @group.name
+                %ul.member-list
+                    Member :
+                    - @group.users.each do |member| 
+                        %li.member-list__member
+                            = member.name
             .header__edit-btn
                 Edit
         .messages


### PR DESCRIPTION
チャット側のヘッダーに現在表示されているグループ名とその下のメンバー一覧に所属しているメンバーが表示されるようにした。